### PR TITLE
🔧chore: jacoco 설정

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-@stophwan @jm0514
+* @stophwan @jm0514

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: ci
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew build

--- a/build.gradle
+++ b/build.gradle
@@ -2,12 +2,14 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.2.2'
 	id 'io.spring.dependency-management' version '1.1.4'
+	id 'jacoco'
 }
 
 subprojects {
 	apply plugin: 'java'
 	apply plugin: 'org.springframework.boot'
 	apply plugin: 'io.spring.dependency-management'
+	apply plugin: 'jacoco'
 
 	group = 'com.dnd'
 	version = '0.0.1-SNAPSHOT'
@@ -32,7 +34,55 @@ subprojects {
 		testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	}
 
+	jacoco {
+		toolVersion = '0.8.8'
+	}
+
+	def jacocoDir = layout.buildDirectory.dir("reports/")
+
+	def QDomains = []
+	for (qPattern in '*.QA'..'*.QZ') { // qPattern = '*.QA', '*.QB', ... '*.QZ'
+		QDomains.add(qPattern + '*')
+	}
+
+	def jacocoExcludePatterns = [
+			// 측정 안하고 싶은 패턴
+			"**/*Application*",
+			"**/*Config*",
+			"**/*Exception*",
+			"**/*Request*",
+			"**/*Response*",
+			"**/*Dto*",
+			"**/*Interceptor*",
+			"**/*Filter*",
+			"**/*Resolver*"
+	]
+
+	jacocoTestReport {
+		dependsOn test
+		reports {
+			html.required.set(true)
+			xml.required.set(true)
+			csv.required.set(false)
+			html.destination jacocoDir.get().file("jacoco/test/index.html").asFile
+			xml.destination jacocoDir.get().file("jacoco/test/index.xml").asFile
+		}
+
+		afterEvaluate {
+			classDirectories.setFrom(
+					files(classDirectories.files.collect {
+						fileTree(dir: it, excludes: jacocoExcludePatterns + QDomains) // Querydsl 관련 제거
+					})
+			)
+		}
+	}
+
 	tasks.named('test') {
 		useJUnitPlatform()
+		finalizedBy jacocoTestReport
 	}
+}
+
+bootJar {
+	enabled = false
 }


### PR DESCRIPTION
### 🧷 Issue Number
 - Resolve: #3 

### 🖋 Description
- Jacoco를 세팅했습니다.
- codecov를 통해 jacocoReport를 업로드, sonarcloud를 사용해 정적 코드 분석을 실시하려고 했으나 사용하려면 해당 organization의 관리자의 허락이 있어야 하더라고요...? codecov는 요청 보내봤는데 허락 오는거 보고 sonarcloud도 스리슬쩍 날려보겠습니다.
- 아니면 다른 gitactions 사용해서 테스트 결과를 확인할 수 있는 방법이 있더라구요! https://velog.io/@ohzzi/%EC%9A%B0%EC%95%84%ED%95%9C%ED%85%8C%ED%81%AC%EC%BD%94%EC%8A%A4-4%EA%B8%B0-220802-F12-%EA%B0%9C%EB%B0%9C%EC%9D%BC%EC%A7%80