### PR TITLE
✨feature: 전역 에러 핸들링

### DIFF
--- a/basterdz-api/build.gradle
+++ b/basterdz-api/build.gradle
@@ -4,4 +4,5 @@ jar { enabled = false }
 dependencies {
     implementation project(":basterdz-domain")
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation:'
 }

--- a/basterdz-api/src/main/java/com/dnd/common/ErrorCode.java
+++ b/basterdz-api/src/main/java/com/dnd/common/ErrorCode.java
@@ -1,0 +1,14 @@
+package com.dnd.common;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+
+	SAMPLE_ERROR("SAMPLE-01", "Sample Error Message");
+
+	private final String code;
+	private final String message;
+}

--- a/basterdz-api/src/main/java/com/dnd/common/GlobalExceptionHandler.java
+++ b/basterdz-api/src/main/java/com/dnd/common/GlobalExceptionHandler.java
@@ -1,0 +1,63 @@
+package com.dnd.common;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.dnd.common.dto.ApiResult;
+import com.dnd.common.error.BasterdzException;
+import com.dnd.common.error.NotFoundException;
+
+import jakarta.validation.UnexpectedTypeException;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	@ExceptionHandler({
+		IllegalArgumentException.class, IllegalStateException.class,
+		HttpMessageNotReadableException.class, UnexpectedTypeException.class
+	})
+	public ApiResult<?> handleBadRequestException(Exception e) {
+		log.debug("Bad request exception occurred: {}", e.getMessage(), e);
+		return ApiResult.error(HttpStatus.BAD_REQUEST, e);
+	}
+
+	@ResponseStatus(HttpStatus.METHOD_NOT_ALLOWED)
+	@ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+	public ApiResult<?> handleHttpMediaTypeException(Exception e) {
+		return ApiResult.error(HttpStatus.UNSUPPORTED_MEDIA_TYPE, e);
+	}
+
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ApiResult<?> handleRequestValidException(MethodArgumentNotValidException e) {
+		StringBuilder builder = new StringBuilder();
+		e.getBindingResult().getFieldErrors().forEach(fieldError ->
+			builder.append(String.format("[%s](은)는 %s, 입력된 값: %s|",
+				fieldError.getField(),
+				fieldError.getDefaultMessage(),
+				fieldError.getRejectedValue())));
+		return ApiResult.error(HttpStatus.BAD_REQUEST, "COMMON-02", builder.toString());
+	}
+
+	@ExceptionHandler(BasterdzException.class)
+	public ApiResult<?> handleBasterdzException(BasterdzException e) {
+		if (e instanceof NotFoundException)
+			return ApiResult.error(HttpStatus.NOT_FOUND, e.getCode(), e.getMessage());
+		return ApiResult.error(HttpStatus.INTERNAL_SERVER_ERROR, e);
+	}
+
+	@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+	@ExceptionHandler({Exception.class, RuntimeException.class})
+	public ApiResult<?> handleException(Exception e) {
+		log.error("Unexpected exception occurred: {}", e.getMessage(), e);
+		return ApiResult.error(HttpStatus.INTERNAL_SERVER_ERROR, e);
+	}
+}

--- a/basterdz-api/src/main/java/com/dnd/common/SampleController.java
+++ b/basterdz-api/src/main/java/com/dnd/common/SampleController.java
@@ -1,0 +1,26 @@
+package com.dnd.common;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.dnd.common.dto.ApiResult;
+
+import jakarta.validation.Valid;
+
+@RestController
+@RequestMapping("/api/v1/sample")
+public class SampleController {
+
+	@GetMapping("/success")
+	public ApiResult<SampleResponseDto> sampleSuccessApi(@RequestBody @Valid SampleRequestDto sampleRequestDto) {
+		return ApiResult.ok(new SampleResponseDto(1L, "content"));
+	}
+
+	@GetMapping("/fail")
+	public ApiResult<SampleResponseDto> sampleErrorApi() {
+		throw new IllegalArgumentException("");
+	}
+
+}

--- a/basterdz-api/src/main/java/com/dnd/common/SampleRequestDto.java
+++ b/basterdz-api/src/main/java/com/dnd/common/SampleRequestDto.java
@@ -1,0 +1,10 @@
+package com.dnd.common;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record SampleRequestDto(
+	@NotBlank(message = "ss")
+	String id
+){
+
+}

--- a/basterdz-api/src/main/java/com/dnd/common/SampleResponseDto.java
+++ b/basterdz-api/src/main/java/com/dnd/common/SampleResponseDto.java
@@ -1,0 +1,6 @@
+package com.dnd.common;
+
+public record SampleResponseDto(
+	Long id,
+	String content
+){}

--- a/basterdz-api/src/main/java/com/dnd/common/dto/ApiError.java
+++ b/basterdz-api/src/main/java/com/dnd/common/dto/ApiError.java
@@ -1,0 +1,23 @@
+package com.dnd.common.dto;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+
+@Getter
+public class ApiError {
+
+	private final int status;
+	private final String code;
+	private final String message;
+
+	public ApiError(HttpStatus status, Throwable throwable) {
+		this(status, null, throwable.getMessage());
+	}
+
+	public ApiError(HttpStatus status, String code, String message) {
+		this.status = status.value();
+		this.code = code;
+		this.message = message;
+	}
+}

--- a/basterdz-api/src/main/java/com/dnd/common/dto/ApiResult.java
+++ b/basterdz-api/src/main/java/com/dnd/common/dto/ApiResult.java
@@ -1,0 +1,27 @@
+package com.dnd.common.dto;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ApiResult<T> {
+
+	private final boolean success;
+	private final T data;
+	private final ApiError error;
+
+	public static <T> ApiResult<T> ok(T data) {
+		return new ApiResult<>(true, data, null);
+	}
+
+	public static ApiResult<?> error(HttpStatus status, Throwable throwable) {
+		return new ApiResult<>(false, null, new ApiError(status, throwable));
+	}
+
+	public static ApiResult<?> error(HttpStatus status, String code, String message) {
+		return new ApiResult<>(false, null, new ApiError(status, code, message));
+	}
+}

--- a/basterdz-api/src/main/java/com/dnd/common/error/BasterdzException.java
+++ b/basterdz-api/src/main/java/com/dnd/common/error/BasterdzException.java
@@ -1,0 +1,18 @@
+package com.dnd.common.error;
+
+import com.dnd.common.ErrorCode;
+
+import lombok.Getter;
+
+@Getter
+public abstract class BasterdzException extends RuntimeException {
+
+	private final String code;
+	private final String message;
+
+	public BasterdzException(ErrorCode errorCode) {
+		this.code = errorCode.getCode();
+		this.message = errorCode.getMessage();
+	}
+
+}

--- a/basterdz-api/src/main/java/com/dnd/common/error/NotFoundException.java
+++ b/basterdz-api/src/main/java/com/dnd/common/error/NotFoundException.java
@@ -1,0 +1,10 @@
+package com.dnd.common.error;
+
+import com.dnd.common.ErrorCode;
+
+public class NotFoundException extends BasterdzException {
+
+	public NotFoundException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+}

--- a/basterdz-api/src/main/java/com/dnd/common/error/UnauthorizedException.java
+++ b/basterdz-api/src/main/java/com/dnd/common/error/UnauthorizedException.java
@@ -1,0 +1,9 @@
+package com.dnd.common.error;
+
+import com.dnd.common.ErrorCode;
+
+public class UnauthorizedException extends BasterdzException {
+	public UnauthorizedException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+}


### PR DESCRIPTION
### 🧷 Issue Number
 - Resolve: #10 

### 🖋 Description
- ErrorCode에 대해 세부적인 내용 수정이 필요하지만 일단 미리 PR 올립니다!
- 전역 에러를 GlobalExceptionHandler에서 구현하였습니다.
- 401, 404에 맞는 상태코드를 반환하기 위해 BasterdzException을 상속받는 UnauthorizedException과 NotFoundException을 만들었습니다.