### PR TITLE
♻️ refactor: 에러 핸들링 리팩토링 및 에러코드 추가

### DIFF
--- a/basterdz-api/src/main/java/com/dnd/common/ErrorCode.java
+++ b/basterdz-api/src/main/java/com/dnd/common/ErrorCode.java
@@ -1,5 +1,7 @@
 package com.dnd.common;
 
+import org.springframework.http.HttpStatus;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -7,8 +9,19 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ErrorCode {
 
-	SAMPLE_ERROR("SAMPLE-01", "Sample Error Message");
+	//common
+	BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON-01", ""),
+	METHOD_ARGUMENT_NOT_VALID(HttpStatus.BAD_REQUEST, "COMMON-02", ""),
+	UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON-03", ""),
+	FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON-04", ""),
+	NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON-05", ""),
+	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMMON-06", ""),
+	UNSUPPORTED_MEDIA_TYPE(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "COMMON-07", ""),
+	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON-08", "");
+
+	private final HttpStatus status;
 
 	private final String code;
+
 	private final String message;
 }

--- a/basterdz-api/src/main/java/com/dnd/common/GlobalExceptionHandler.java
+++ b/basterdz-api/src/main/java/com/dnd/common/GlobalExceptionHandler.java
@@ -1,63 +1,80 @@
 package com.dnd.common;
 
+import org.springframework.beans.TypeMismatchException;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpMediaTypeException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MultipartException;
 
 import com.dnd.common.dto.ApiResult;
 import com.dnd.common.error.BasterdzException;
 import com.dnd.common.error.NotFoundException;
+import com.dnd.common.error.UnauthorizedException;
 
-import jakarta.validation.UnexpectedTypeException;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	private ResponseEntity<?> newResponse(ErrorCode errorCode) {
+		return new ResponseEntity<>(ApiResult.error(errorCode), errorCode.getStatus());
+	}
+
+	private ResponseEntity<?> newResponseWithMessage(ErrorCode errorCode, String message) {
+		return new ResponseEntity<>(ApiResult.error(errorCode, message), errorCode.getStatus());
+	}
+
 	@ExceptionHandler({
-		IllegalArgumentException.class, IllegalStateException.class,
-		HttpMessageNotReadableException.class, UnexpectedTypeException.class
+		IllegalStateException.class, IllegalArgumentException.class,
+		TypeMismatchException.class, HttpMessageNotReadableException.class,
+		MissingServletRequestParameterException.class, MultipartException.class,
 	})
-	public ApiResult<?> handleBadRequestException(Exception e) {
+	public ResponseEntity<?> handleBadRequestException(Exception e) {
 		log.debug("Bad request exception occurred: {}", e.getMessage(), e);
-		return ApiResult.error(HttpStatus.BAD_REQUEST, e);
+		return newResponse(ErrorCode.BAD_REQUEST);
 	}
 
-	@ResponseStatus(HttpStatus.METHOD_NOT_ALLOWED)
-	@ExceptionHandler(HttpRequestMethodNotSupportedException.class)
-	public ApiResult<?> handleHttpMediaTypeException(Exception e) {
-		return ApiResult.error(HttpStatus.UNSUPPORTED_MEDIA_TYPE, e);
-	}
-
-	@ResponseStatus(HttpStatus.BAD_REQUEST)
 	@ExceptionHandler(MethodArgumentNotValidException.class)
-	public ApiResult<?> handleRequestValidException(MethodArgumentNotValidException e) {
+	public ResponseEntity<?> handleRequestValidException(MethodArgumentNotValidException e) {
 		StringBuilder builder = new StringBuilder();
 		e.getBindingResult().getFieldErrors().forEach(fieldError ->
-			builder.append(String.format("[%s](은)는 %s, 입력된 값: %s|",
+			builder.append(String.format("[%s](은)는 %s|",
 				fieldError.getField(),
-				fieldError.getDefaultMessage(),
-				fieldError.getRejectedValue())));
-		return ApiResult.error(HttpStatus.BAD_REQUEST, "COMMON-02", builder.toString());
+				fieldError.getDefaultMessage())));
+		return newResponseWithMessage(ErrorCode.METHOD_ARGUMENT_NOT_VALID, builder.toString());
+	}
+
+	@ExceptionHandler(HttpMediaTypeException.class)
+	public ResponseEntity<?> handleHttpMediaTypeException(Exception e) {
+		return newResponse(ErrorCode.UNSUPPORTED_MEDIA_TYPE);
+	}
+
+	@ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+	public ResponseEntity<?> handleMethodNotAllowedException(Exception e) {
+		return newResponse(ErrorCode.METHOD_NOT_ALLOWED);
 	}
 
 	@ExceptionHandler(BasterdzException.class)
-	public ApiResult<?> handleBasterdzException(BasterdzException e) {
+	public ResponseEntity<?> handleBasterdzException(BasterdzException e) {
+		if (e instanceof UnauthorizedException)
+			return newResponse(ErrorCode.UNAUTHORIZED);
 		if (e instanceof NotFoundException)
-			return ApiResult.error(HttpStatus.NOT_FOUND, e.getCode(), e.getMessage());
-		return ApiResult.error(HttpStatus.INTERNAL_SERVER_ERROR, e);
+			return newResponse(ErrorCode.NOT_FOUND);
+		return newResponse(ErrorCode.INTERNAL_SERVER_ERROR);
 	}
 
 	@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
 	@ExceptionHandler({Exception.class, RuntimeException.class})
-	public ApiResult<?> handleException(Exception e) {
+	public ResponseEntity<?> handleException(Exception e) {
 		log.error("Unexpected exception occurred: {}", e.getMessage(), e);
-		return ApiResult.error(HttpStatus.INTERNAL_SERVER_ERROR, e);
+		return newResponse(ErrorCode.INTERNAL_SERVER_ERROR);
 	}
 }

--- a/basterdz-api/src/main/java/com/dnd/common/SampleController.java
+++ b/basterdz-api/src/main/java/com/dnd/common/SampleController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.dnd.common.dto.ApiResult;
+import com.dnd.common.error.NotFoundException;
 
 import jakarta.validation.Valid;
 
@@ -20,7 +21,7 @@ public class SampleController {
 
 	@GetMapping("/fail")
 	public ApiResult<SampleResponseDto> sampleErrorApi() {
-		throw new IllegalArgumentException("");
+		throw new NotFoundException(ErrorCode.NOT_FOUND);
 	}
 
 }

--- a/basterdz-api/src/main/java/com/dnd/common/SampleRequestDto.java
+++ b/basterdz-api/src/main/java/com/dnd/common/SampleRequestDto.java
@@ -3,7 +3,7 @@ package com.dnd.common;
 import jakarta.validation.constraints.NotBlank;
 
 public record SampleRequestDto(
-	@NotBlank(message = "ss")
+	@NotBlank(message = "빈칸이 올 수 없습니다")
 	String id
 ){
 

--- a/basterdz-api/src/main/java/com/dnd/common/dto/ApiError.java
+++ b/basterdz-api/src/main/java/com/dnd/common/dto/ApiError.java
@@ -1,23 +1,24 @@
 package com.dnd.common.dto;
 
-import org.springframework.http.HttpStatus;
+import com.dnd.common.ErrorCode;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class ApiError {
 
 	private final int status;
 	private final String code;
 	private final String message;
 
-	public ApiError(HttpStatus status, Throwable throwable) {
-		this(status, null, throwable.getMessage());
+	public ApiError(ErrorCode errorCode) {
+		this(errorCode.getStatus().value(), errorCode.getCode(), errorCode.getMessage());
 	}
 
-	public ApiError(HttpStatus status, String code, String message) {
-		this.status = status.value();
-		this.code = code;
-		this.message = message;
+	public ApiError(ErrorCode errorCode, String message) {
+		this(errorCode.getStatus().value(), errorCode.getCode(), message);
 	}
+
 }

--- a/basterdz-api/src/main/java/com/dnd/common/dto/ApiResult.java
+++ b/basterdz-api/src/main/java/com/dnd/common/dto/ApiResult.java
@@ -1,6 +1,6 @@
 package com.dnd.common.dto;
 
-import org.springframework.http.HttpStatus;
+import com.dnd.common.ErrorCode;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -17,11 +17,12 @@ public class ApiResult<T> {
 		return new ApiResult<>(true, data, null);
 	}
 
-	public static ApiResult<?> error(HttpStatus status, Throwable throwable) {
-		return new ApiResult<>(false, null, new ApiError(status, throwable));
+	public static ApiResult<?> error(ErrorCode errorCode) {
+		return new ApiResult<>(false, null, new ApiError(errorCode));
 	}
 
-	public static ApiResult<?> error(HttpStatus status, String code, String message) {
-		return new ApiResult<>(false, null, new ApiError(status, code, message));
+	public static ApiResult<?> error(ErrorCode errorCode, String message) {
+		return new ApiResult<>(false, null, new ApiError(errorCode, message));
 	}
+
 }

--- a/basterdz-api/src/main/java/com/dnd/common/error/BasterdzException.java
+++ b/basterdz-api/src/main/java/com/dnd/common/error/BasterdzException.java
@@ -7,12 +7,10 @@ import lombok.Getter;
 @Getter
 public abstract class BasterdzException extends RuntimeException {
 
-	private final String code;
-	private final String message;
+	private final ErrorCode errorCode;
 
 	public BasterdzException(ErrorCode errorCode) {
-		this.code = errorCode.getCode();
-		this.message = errorCode.getMessage();
+		this.errorCode = errorCode;
 	}
 
 }

--- a/basterdz-api/src/main/resources/application.yml
+++ b/basterdz-api/src/main/resources/application.yml
@@ -1,0 +1,6 @@
+spring:
+  profiles:
+    default: local
+  config:
+    import:
+      - db-local.yml

--- a/basterdz-domain/src/main/resources/db-local.yml
+++ b/basterdz-domain/src/main/resources/db-local.yml
@@ -1,0 +1,12 @@
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:33006/basterdzdb?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: root
+    password: nophone
+
+  jpa:
+    open-in-view: false
+    properties:
+      hibernate.format_sql: true
+      dialect: org.hibernate.dialect.MySQL8InnoDBDialect


### PR DESCRIPTION
### 🧷 Issue Number
 - Resolve: #16 

### 🖋 Description
- 전역 에러 핸들러의 리턴타입을 ApiResponse -> ResponseEntity로 변경하였습니다.
- Throwble의 message가 클라이언트에게 노출되지 않게 변경하였습니다. 
- 이를 위해 기존 샘플 에러코드에서 400 BadRequest, 500 Internal Server Error와 같은 공통 에러를 추가하였습니다.
- application.yml파일을 api 모듈에 작성했습니다. 다른 모듈에서 yml작성시 api에 있는 application.yml파일에 Import 해주어야합니다.