### PR TITLE
✨ feat: 방 멤버의 당일 날짜 스크린 사용시간 조회 기능 구현

### DIFF
--- a/basterdz-api/src/main/java/com/dnd/api/common/random/LocalDateHolder.java
+++ b/basterdz-api/src/main/java/com/dnd/api/common/random/LocalDateHolder.java
@@ -1,4 +1,4 @@
-package com.dnd.util;
+package com.dnd.api.common.random;
 
 import java.time.LocalDate;
 

--- a/basterdz-api/src/main/java/com/dnd/api/common/random/SystemLocalDateHolder.java
+++ b/basterdz-api/src/main/java/com/dnd/api/common/random/SystemLocalDateHolder.java
@@ -1,0 +1,13 @@
+package com.dnd.api.common.random;
+
+import java.time.LocalDate;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class SystemLocalDateHolder implements LocalDateHolder {
+	@Override
+	public LocalDate today() {
+		return LocalDate.now();
+	}
+}

--- a/basterdz-api/src/main/java/com/dnd/api/domains/room/controller/RoomReportApiPresentation.java
+++ b/basterdz-api/src/main/java/com/dnd/api/domains/room/controller/RoomReportApiPresentation.java
@@ -1,0 +1,29 @@
+package com.dnd.api.domains.room.controller;
+
+import java.util.List;
+
+import com.dnd.api.common.dto.ApiResult;
+import com.dnd.api.domains.room.dto.RoomMemberScreenTimeResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "\uD83C\uDFE0Room", description = "Room API")
+public interface RoomReportApiPresentation {
+
+	@Operation(summary = "방 내 멤버 현재 스크린 타임 조회")
+	@ApiResponses(
+		value = {
+			@ApiResponse(responseCode = "200", description = "스크린 타임 조회 성공"),
+			@ApiResponse(responseCode = "404", description = "존재하지 않는 그룹",
+				content = @Content(schema = @Schema(
+					example = "{\"success\": false, \"data\" : null,"
+						+ "\"error\": {\"code\": \"ROOM-01\", \"message\": \"존재하지 않는 그룹입니다.\"}}")))
+		}
+	)
+	ApiResult<List<RoomMemberScreenTimeResponse>> findRoomMemberScreenTime(Long roomId);
+}

--- a/basterdz-api/src/main/java/com/dnd/api/domains/room/controller/RoomReportController.java
+++ b/basterdz-api/src/main/java/com/dnd/api/domains/room/controller/RoomReportController.java
@@ -1,0 +1,30 @@
+package com.dnd.api.domains.room.controller;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.dnd.api.common.dto.ApiResult;
+import com.dnd.api.domains.room.dto.RoomMemberScreenTimeResponse;
+import com.dnd.api.domains.room.service.RoomReportService;
+import com.dnd.domain.room.dto.RoomMemberDailyScreenTime;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/v1/rooms")
+@RequiredArgsConstructor
+public class RoomReportController implements RoomReportApiPresentation {
+
+	private final RoomReportService roomReportService;
+
+	@GetMapping("/{roomId}/screen-time")
+	public ApiResult<List<RoomMemberScreenTimeResponse>> findRoomMemberScreenTime(@PathVariable Long roomId) {
+		List<RoomMemberDailyScreenTime> roomMemberDailyScreenTimes = roomReportService.findRoomMemberScreenTime(roomId);
+		return ApiResult.ok(roomMemberDailyScreenTimes.stream().map(RoomMemberScreenTimeResponse::from).toList());
+	}
+
+}

--- a/basterdz-api/src/main/java/com/dnd/api/domains/room/dto/RoomMemberScreenTimeResponse.java
+++ b/basterdz-api/src/main/java/com/dnd/api/domains/room/dto/RoomMemberScreenTimeResponse.java
@@ -1,0 +1,46 @@
+package com.dnd.api.domains.room.dto;
+
+import static lombok.AccessLevel.PROTECTED;
+
+import com.dnd.domain.room.dto.RoomMemberDailyScreenTime;
+import com.dnd.common.util.TimeConvertUtils;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = PROTECTED)
+@AllArgsConstructor(access = PROTECTED)
+public class RoomMemberScreenTimeResponse {
+
+	@Schema(name = "memberId", example = "1")
+	private Long memberId;
+
+	@Schema(name = "nickName", example = "지환")
+	private String nickName;
+
+	@Schema(name = "nickName", example = "02:00")
+	private String usageTime;
+
+	@Schema(name = "percent", example = "0.5")
+	private double percent;
+
+	@Schema(name = "percent", example = "false")
+	private boolean isExceed;
+
+	public static RoomMemberScreenTimeResponse from(RoomMemberDailyScreenTime roomMemberDailyScreenTime) {
+		return RoomMemberScreenTimeResponse.builder()
+			.memberId(roomMemberDailyScreenTime.getMemberId())
+			.nickName(roomMemberDailyScreenTime.getNickName())
+			.usageTime(TimeConvertUtils.convertMinutesToTimeString(roomMemberDailyScreenTime.getDuration()))
+			.percent(roomMemberDailyScreenTime.getPercent())
+			.isExceed(roomMemberDailyScreenTime.getIsExceed())
+			.build();
+	}
+
+
+}

--- a/basterdz-api/src/main/java/com/dnd/api/domains/room/service/RoomReportService.java
+++ b/basterdz-api/src/main/java/com/dnd/api/domains/room/service/RoomReportService.java
@@ -1,0 +1,26 @@
+package com.dnd.api.domains.room.service;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.dnd.api.common.random.LocalDateHolder;
+import com.dnd.domain.room.dto.RoomMemberDailyScreenTime;
+import com.dnd.domain.room.implement.RoomReportFinder;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class RoomReportService {
+
+	private final RoomReportFinder roomReportFinder;
+	private final LocalDateHolder localDateHolder;
+
+	public List<RoomMemberDailyScreenTime> findRoomMemberScreenTime(Long roomId) {
+		LocalDate today = localDateHolder.today();
+		return roomReportFinder.findRoomMemberDailyScreenTime(roomId, today);
+	}
+
+}

--- a/basterdz-batch/src/main/java/com/dnd/batch/RankingJob.java
+++ b/basterdz-batch/src/main/java/com/dnd/batch/RankingJob.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 
 import com.dnd.domain.room.dto.RoomMemberRankingDto;
 import com.dnd.domain.room.implement.RoomFinder;
+import com.dnd.domain.room.implement.RoomReportFinder;
 import com.dnd.util.LocalDateHolder;
 
 import lombok.RequiredArgsConstructor;
@@ -15,13 +16,13 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class RankingJob {
 
-	private final RoomFinder roomFinder;
+	private final RoomReportFinder roomReportFinder;
 	private final LocalDateHolder localDateHolder;
 
 	//TODO 방별 멤버 사용량을 Redis에 저장
 	public void run() {
 		LocalDate yesterday = localDateHolder.today().minusDays(1);
-		List<RoomMemberRankingDto> roomMemberRankings = roomFinder.findRoomMemberRankingDto(yesterday);
+		List<RoomMemberRankingDto> roomMemberRankings = roomReportFinder.findRoomMemberRankingDto(yesterday);
 	}
 
 }

--- a/basterdz-batch/src/main/java/com/dnd/batch/RankingJob.java
+++ b/basterdz-batch/src/main/java/com/dnd/batch/RankingJob.java
@@ -5,10 +5,9 @@ import java.util.List;
 
 import org.springframework.stereotype.Service;
 
+import com.dnd.batch.random.LocalDateHolder;
 import com.dnd.domain.room.dto.RoomMemberRankingDto;
-import com.dnd.domain.room.implement.RoomFinder;
 import com.dnd.domain.room.implement.RoomReportFinder;
-import com.dnd.util.LocalDateHolder;
 
 import lombok.RequiredArgsConstructor;
 

--- a/basterdz-batch/src/main/java/com/dnd/batch/random/LocalDateHolder.java
+++ b/basterdz-batch/src/main/java/com/dnd/batch/random/LocalDateHolder.java
@@ -1,0 +1,8 @@
+package com.dnd.batch.random;
+
+import java.time.LocalDate;
+
+public interface LocalDateHolder {
+	LocalDate today();
+
+}

--- a/basterdz-batch/src/main/java/com/dnd/batch/random/SystemLocalDateHolder.java
+++ b/basterdz-batch/src/main/java/com/dnd/batch/random/SystemLocalDateHolder.java
@@ -1,7 +1,10 @@
-package com.dnd.util;
+package com.dnd.batch.random;
 
 import java.time.LocalDate;
 
+import org.springframework.stereotype.Component;
+
+@Component
 public class SystemLocalDateHolder implements LocalDateHolder {
 	@Override
 	public LocalDate today() {

--- a/basterdz-common/src/main/java/com/dnd/common/util/TimeConvertUtils.java
+++ b/basterdz-common/src/main/java/com/dnd/common/util/TimeConvertUtils.java
@@ -1,4 +1,4 @@
-package com.dnd.util;
+package com.dnd.common.util;
 
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;

--- a/basterdz-common/src/main/java/com/dnd/util/TimeConvertUtils.java
+++ b/basterdz-common/src/main/java/com/dnd/util/TimeConvertUtils.java
@@ -1,0 +1,19 @@
+package com.dnd.util;
+
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+
+public class TimeConvertUtils {
+
+	public static int convertTimeStringToMinutes(String time) {
+		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm");
+		LocalTime localTime = LocalTime.parse(time, formatter);
+		return localTime.getHour() * 60 + localTime.getMinute();
+	}
+
+	public static String convertMinutesToTimeString(int minutes) {
+		int hours = minutes / 60;
+		minutes %= 60;
+		return String.format("%02d:%02d", hours, minutes);
+	}
+}

--- a/basterdz-domain/src/main/java/com/dnd/domain/room/dto/RoomMemberDailyScreenTime.java
+++ b/basterdz-domain/src/main/java/com/dnd/domain/room/dto/RoomMemberDailyScreenTime.java
@@ -1,0 +1,19 @@
+package com.dnd.domain.room.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RoomMemberDailyScreenTime {
+
+	private Long memberId;
+
+	private String nickName;
+
+	private int limitHour;
+
+	private int duration;
+}

--- a/basterdz-domain/src/main/java/com/dnd/domain/room/dto/RoomMemberDailyScreenTime.java
+++ b/basterdz-domain/src/main/java/com/dnd/domain/room/dto/RoomMemberDailyScreenTime.java
@@ -16,4 +16,14 @@ public class RoomMemberDailyScreenTime {
 	private int limitHour;
 
 	private int duration;
+
+	public double getPercent() {
+		double ratio = (double)duration / (limitHour*60);
+		if(ratio > 1.0) ratio = 1.0;
+		return Math.round(ratio * 100)/100.0;
+	}
+
+	public boolean getIsExceed() {
+		return duration > limitHour;
+	}
 }

--- a/basterdz-domain/src/main/java/com/dnd/domain/room/implement/RoomFinder.java
+++ b/basterdz-domain/src/main/java/com/dnd/domain/room/implement/RoomFinder.java
@@ -3,15 +3,10 @@ package com.dnd.domain.room.implement;
 import static com.dnd.common.exception.ErrorCode.INVALID_INVITE_CODE;
 import static com.dnd.common.exception.ErrorCode.ROOM_NOT_FOUND;
 
-import java.time.LocalDate;
-import java.util.List;
-
 import com.dnd.common.exception.BadRequestException;
 import com.dnd.common.exception.NotFoundException;
 import com.dnd.domain.common.annotation.Finder;
 import com.dnd.domain.room.repository.RoomJpaRepository;
-import com.dnd.domain.room.repository.RoomMemberQueryRepository;
-import com.dnd.domain.room.dto.RoomMemberRankingDto;
 import com.dnd.domain.room.entity.Room;
 
 import lombok.RequiredArgsConstructor;
@@ -21,7 +16,6 @@ import lombok.RequiredArgsConstructor;
 public class RoomFinder {
 
 	private final RoomJpaRepository roomJpaRepository;
-	private final RoomMemberQueryRepository roomMemberQueryRepository;
 
 	public Room find(final Long roomId) {
 		return roomJpaRepository.findById(roomId)
@@ -32,9 +26,4 @@ public class RoomFinder {
 		return roomJpaRepository.findByInviteCode(inviteCode)
 			.orElseThrow(() -> new BadRequestException(INVALID_INVITE_CODE));
 	}
-
-	public List<RoomMemberRankingDto> findRoomMemberRankingDto(final LocalDate usageDate) {
-		return roomMemberQueryRepository.searchRoomMemberRankingByUsageDate(usageDate);
-	}
-
 }

--- a/basterdz-domain/src/main/java/com/dnd/domain/room/implement/RoomReportFinder.java
+++ b/basterdz-domain/src/main/java/com/dnd/domain/room/implement/RoomReportFinder.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class RoomReportFinder {
 
+	private final RoomFinder roomFinder;
 	private final RoomMemberQueryRepository roomMemberQueryRepository;
 
 	public List<RoomMemberRankingDto> findRoomMemberRankingDto(final LocalDate usageDate) {
@@ -21,6 +22,7 @@ public class RoomReportFinder {
 	}
 
 	public List<RoomMemberDailyScreenTime> findRoomMemberDailyScreenTime(Long roomId, LocalDate today) {
+		roomFinder.find(roomId);
 		return roomMemberQueryRepository.findRoomMemberScreenTimeByRoomIdAndLocalDate(roomId, today);
 	}
 }

--- a/basterdz-domain/src/main/java/com/dnd/domain/room/implement/RoomReportFinder.java
+++ b/basterdz-domain/src/main/java/com/dnd/domain/room/implement/RoomReportFinder.java
@@ -14,7 +14,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class RoomReportFinder {
 
-	private final RoomFinder roomFinder;
 	private final RoomMemberQueryRepository roomMemberQueryRepository;
 
 	public List<RoomMemberRankingDto> findRoomMemberRankingDto(final LocalDate usageDate) {
@@ -22,7 +21,6 @@ public class RoomReportFinder {
 	}
 
 	public List<RoomMemberDailyScreenTime> findRoomMemberDailyScreenTime(Long roomId, LocalDate today) {
-		roomFinder.find(roomId);
 		return roomMemberQueryRepository.findRoomMemberScreenTimeByRoomIdAndLocalDate(roomId, today);
 	}
 }

--- a/basterdz-domain/src/main/java/com/dnd/domain/room/implement/RoomReportFinder.java
+++ b/basterdz-domain/src/main/java/com/dnd/domain/room/implement/RoomReportFinder.java
@@ -1,0 +1,26 @@
+package com.dnd.domain.room.implement;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import com.dnd.domain.common.annotation.Finder;
+import com.dnd.domain.room.dto.RoomMemberDailyScreenTime;
+import com.dnd.domain.room.dto.RoomMemberRankingDto;
+import com.dnd.domain.room.repository.RoomMemberQueryRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Finder
+@RequiredArgsConstructor
+public class RoomReportFinder {
+
+	private final RoomMemberQueryRepository roomMemberQueryRepository;
+
+	public List<RoomMemberRankingDto> findRoomMemberRankingDto(final LocalDate usageDate) {
+		return roomMemberQueryRepository.searchRoomMemberRankingByUsageDate(usageDate);
+	}
+
+	public List<RoomMemberDailyScreenTime> findRoomMemberDailyScreenTime(Long roomId, LocalDate today) {
+		return roomMemberQueryRepository.findRoomMemberScreenTimeByRoomIdAndLocalDate(roomId, today);
+	}
+}

--- a/basterdz-domain/src/main/resources/db-local.yml
+++ b/basterdz-domain/src/main/resources/db-local.yml
@@ -1,7 +1,7 @@
 spring:
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:33006/basterdzdb?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    url: jdbc:mysql://localhost:33006/basterdzdb
     username: root
     password: nophone
 

--- a/docker/basterdz-container/docker-compose.local.yml
+++ b/docker/basterdz-container/docker-compose.local.yml
@@ -12,5 +12,5 @@ services:
       MYSQL_ROOT_PASSWORD: nophone
       TZ: "Asia/Seoul"
     command:
-      - --character-set-server=utf8mb4
-      - --collation-server=utf8mb4_unicode_ci
+      - --character-set-server=utf8
+      - --collation-server=utf8_general_ci


### PR DESCRIPTION
### 🧷 Issue Number
 - Resolve: #44 

### 🖋 Description
- 방 멤버의 당일 날짜 스크린 사용시간 조회 기능을 구현하였습니다.
- TimeConvertUtils 클래스를 작성하였습니다. int형태의 분을 HH:mm형태의 String으로 변환 및 반대로의 변환을 하는 util입니다.
- QueryDSL에서 left join을 한 이유는 해당 멤버의 당일 스크린타임이 없을 경우 00:00이라도 반환하기 위해서 입니다.
- RoomReport~ 클래스에 방이 시작된 후 리포트 형식의 api에 관한 내용의 클래스를 별도로 분리하였습니다.